### PR TITLE
Adding a max_unique_streams count to the config.

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -1,9 +1,10 @@
 [main]
 loop_delay_seconds: 10
+max_unique_streams: 1
 plex_url: http://127.0.0.1:10400
 plex_token: ** Plex Token - https://bit.ly/34FeMCo **
 ban_length_hrs: 48
-ban_msg: YOU HAVE BEEN BANNED FROM PLEX FOR 48 HOURS FOR ACCOUNT SHARING. Please ask @AdminNameHere if you have any questions. This is an automated message
+ban_msg: YOU HAVE BEEN BANNED FROM PLEX FOR 48 HOURS FOR ACCOUNT SHARING. Please ask @AdminNameHere if you have any questions. This is an automated message.
 
 [telegram]
 bot_key: ** Telegram Bot Key - https://bit.ly/33GhZjV **

--- a/dupStreamKiller.py
+++ b/dupStreamKiller.py
@@ -205,7 +205,7 @@ try:
             if user in ban_list:
                 if is_ban_valid(user, ban_list):
                     logging.info(f"Killing all streams for banned user {user}")
-                    kill_all_streams(streams[user], ban_msg + f" Your ban will be lifted in {ban_time_left_human(user, ban_list)}", plex_url, plex_token)
+                    kill_all_streams(streams[user], ban_msg + f" Your ban will be lifted in {ban_time_left_human(user, ban_list)}.", plex_url, plex_token)
                     telegram_notify(f"Prevented banned user {user} from streaming", telegram_bot_key, telegram_chat_id)
                 else:
                     # ban has expired
@@ -222,9 +222,9 @@ try:
                 save_bans(ban_list)
 
                 logging.info(f"Killing all streams for {user}")
-                kill_all_streams(streams[user], ban_msg + f" Your ban will be lifted in {ban_time_left_human(user, ban_list)}", plex_url, plex_token)
+                kill_all_streams(streams[user], ban_msg + f" Your ban will be lifted in {ban_time_left_human(user, ban_list)}.", plex_url, plex_token)
 
-                telegram_notify(f"Banned {user} for {ban_length_hrs} hours for streaming from {uniq_stream_locations} unique locations",
+                telegram_notify(f"Banned {user} for {ban_length_hrs} hours for streaming from {uniq_stream_locations} unique locations.",
                                 telegram_bot_key, telegram_chat_id)
 
         time.sleep(loop_delay_sec)

--- a/dupStreamKiller.py
+++ b/dupStreamKiller.py
@@ -181,6 +181,7 @@ try:
     loop_delay_sec = int(config.get('main', 'loop_delay_seconds'))
     plex_url = config.get('main', 'plex_url')
     plex_token = config.get('main', 'plex_token')
+    max_unique_streams = int(config.get('main', 'max_unique_streams'))
     ban_length_hrs = int(config.get('main', 'ban_length_hrs'))
     ban_msg = config.get('main', 'ban_msg')
     telegram_bot_key = config.get('telegram', 'bot_key')
@@ -215,7 +216,7 @@ try:
 
             # check to see if user needs to be banned
             uniq_stream_locations = dup_check(streams[user])
-            if uniq_stream_locations > 1:
+            if uniq_stream_locations > max_unique_streams:
                 logging.info(f"Banning user {user} for {ban_length_hrs} hours for streaming from {uniq_stream_locations} unique locations")
                 ban_list = ban_user(user, ban_length_hrs, ban_list)
                 save_bans(ban_list)


### PR DESCRIPTION
In a scenario like I'm in, a lot of husbands and wives share the same account, and when the wives are at home, sometime the husband watches from their phone, which causes them to get banned for a legitimate reason. 

I'm submitting the PR to allow a max_unique_streams variable to set a count. You can leave it at 1 for the default settings.