### PR TITLE
Adding whitelist ability

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -5,6 +5,7 @@ plex_url: http://127.0.0.1:10400
 plex_token: ** Plex Token - https://bit.ly/34FeMCo **
 ban_length_hrs: 48
 ban_msg: YOU HAVE BEEN BANNED FROM PLEX FOR 48 HOURS FOR ACCOUNT SHARING. Please ask @AdminNameHere if you have any questions. This is an automated message.
+whitelist: ** Space separated list of users to whitelist. If none, leave blank. **
 
 [telegram]
 bot_key: ** Telegram Bot Key - https://bit.ly/33GhZjV **

--- a/dupStreamKiller.py
+++ b/dupStreamKiller.py
@@ -172,7 +172,7 @@ def telegram_notify(message, telegram_bot_key, chat_id):
 
 
 # set default logging level and stream
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 # load settings
 try:
@@ -184,8 +184,10 @@ try:
     max_unique_streams = int(config.get('main', 'max_unique_streams'))
     ban_length_hrs = int(config.get('main', 'ban_length_hrs'))
     ban_msg = config.get('main', 'ban_msg')
+    whitelist = config.get('main', 'whitelist').split()
     telegram_bot_key = config.get('telegram', 'bot_key')
     telegram_chat_id = config.get('telegram', 'chat_id')
+    print(whitelist)
 except FileNotFoundError as err:
     logging.critical(f"Unable to read config file! Error: {err}")
     exit()

--- a/dupStreamKiller.py
+++ b/dupStreamKiller.py
@@ -172,7 +172,7 @@ def telegram_notify(message, telegram_bot_key, chat_id):
 
 
 # set default logging level and stream
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 # load settings
 try:
@@ -187,7 +187,6 @@ try:
     whitelist = config.get('main', 'whitelist').split()
     telegram_bot_key = config.get('telegram', 'bot_key')
     telegram_chat_id = config.get('telegram', 'chat_id')
-    print(whitelist)
 except FileNotFoundError as err:
     logging.critical(f"Unable to read config file! Error: {err}")
     exit()

--- a/dupStreamKiller.py
+++ b/dupStreamKiller.py
@@ -184,7 +184,7 @@ try:
     max_unique_streams = int(config.get('main', 'max_unique_streams'))
     ban_length_hrs = int(config.get('main', 'ban_length_hrs'))
     ban_msg = config.get('main', 'ban_msg')
-    whitelist = config.get('main', 'whitelist').split()
+    whitelist = config.get('main', 'whitelist').lower().split()
     telegram_bot_key = config.get('telegram', 'bot_key')
     telegram_chat_id = config.get('telegram', 'chat_id')
 except FileNotFoundError as err:
@@ -202,6 +202,11 @@ try:
         streams = get_streams(plex_url, plex_token)
 
         for user in streams:
+            # continue if the user is in a whitelist
+            if user.lower() in whitelist:
+                logging.debug(f"User {user} is in whitelist. Not going to count streams")
+                continue
+
             # check to see if user is already banned
             if user in ban_list:
                 if is_ban_valid(user, ban_list):


### PR DESCRIPTION
This PR is to allow a whitelist to the duplicate stream killer (for example, a Plex admin).

It is a space separated whitelist. 