### PR TITLE
Add Network Whitelist Setting

### DIFF
--- a/app/config.ini.TEMPLATE
+++ b/app/config.ini.TEMPLATE
@@ -4,7 +4,8 @@ plex_url: ${PLEX_URL}
 plex_token: ${PLEX_TOKEN}
 ban_length_hrs: ${BAN_LENGTH_HRS}
 ban_msg: ${BAN_MSG}
-whitelist: ${WHITELIST}
+user_whitelist: ${USER_WHITELIST}
+network_whitelist: ${NETWORK_WHITELIST}
 max_unique_streams: ${MAX_UNIQUE_STREAMS}
 
 [telegram]

--- a/docker-compose.yml.EXAMPLE
+++ b/docker-compose.yml.EXAMPLE
@@ -11,7 +11,8 @@ services:
       MAX_UNIQUE_STREAMS: 1
       BAN_LENGTH_HRS: 48
       BAN_MSG: YOU HAVE BEEN BANNED FROM PLEX FOR 48 HOURS FOR ACCOUNT SHARING. Please ask @AdminNameHere if you have any questions. This is an automated message.
-      WHITELIST:
+      USER_WHITELIST:
+      NETWORK_WHITELIST:
       PLEX_URL: http://127.0.0.1:10400
       PLEX_TOKEN: ** Plex Token - https://bit.ly/34FeMCo **
       TELEGRAM_BOT_KEY: ** Telegram Bot Key - https://bit.ly/33GhZjV **


### PR DESCRIPTION
This enables you to specify a space seperated list of networks in CIDR format. Any streams coming from an IP address inside a given network will be ignored.