### PR TITLE
Better bans.json load fail message

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -104,7 +104,7 @@ def load_bans():
         with open('/data/bans.json', 'r') as f:
             return json.loads(f.read())
     except Exception as err:
-        logging.warning(f'Error loading bans from disk. {err}')
+        logging.info(f'bans.json does not exist or can not be read. This will be created when someone is banned. {err}')
         return {}
     else:
         logging.debug('Loaded bans from disk')


### PR DESCRIPTION
This changes the message that is displayed on startup if `/data/bans.json` does not exist. The message was previously worded as if this was an error. This PR changes it to clearly be an informational message.

Related: #12 